### PR TITLE
fix bug RR-74

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -16,7 +16,6 @@
       top: 8.5rem;
       left: $padding-sm;
       right: $padding-sm;
-      height: 100%;
       @include tablet {
         top: 5.75rem;
         left: $padding-sm;


### PR DESCRIPTION
Fixed annoying overlay bug that impacted everyone

https://brainstationeducation.atlassian.net/browse/RR-74

I had it fixed in my RR-20 feature branch but I didn't want to delay this any further.

Go to pages like http://localhost:3000/warehouses/new to see for an example, even though adjustments may be needed to individual route component to prevent double overlay.
<img width="275" alt="image" src="https://github.com/Sarahstylez/instock/assets/10499747/051d25c8-0f0f-4ac5-a147-dbb33c35bbea">
